### PR TITLE
Remove @types/dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "devDependencies": {
         "@eslint/js": "^9.2.0",
         "@types/bcryptjs": "^2.4.6",
-        "@types/dotenv": "^8.2.0",
         "@types/express": "^4.17.21",
         "@types/node": "^20.12.8",
         "@types/passport-jwt": "^4.0.1",


### PR DESCRIPTION
As the dotenv package types built in we do not need to seprately add @types/dotenv